### PR TITLE
Fix small string overflow

### DIFF
--- a/libknet/ping_test.c
+++ b/libknet/ping_test.c
@@ -501,9 +501,9 @@ int main(int argc, char *argv[])
 		memset(&out_big_buff, 0, sizeof(out_big_buff));
 		memset(&hello_world, 0, sizeof(hello_world));
 
-		snprintf(hello_world+2, sizeof(hello_world), "Hello world!");
-		snprintf(out_big_buff+2, sizeof(out_big_buff), "%zu", sizeof(out_big_buff));
-		snprintf(out_big_frag+2, sizeof(out_big_frag), "%zu", sizeof(out_big_frag));
+		snprintf(hello_world+2, sizeof(hello_world)-2, "Hello world!");
+		snprintf(out_big_buff+2, sizeof(out_big_buff)-2, "%zu", sizeof(out_big_buff));
+		snprintf(out_big_frag+2, sizeof(out_big_frag)-2, "%zu", sizeof(out_big_frag));
 
 		switch(big) {
 			case 0: /* hello world */


### PR DESCRIPTION
In file included from /usr/include/stdio.h:936:0,
                 from ping_test.c:12: In function ‘snprintf’,
    inlined from ‘main’ at ping_test.c:504:3: /usr/include/bits/stdio2.h:64:10: error: call to
__builtin___snprintf_chk will always overflow destination buffer [-Werror]
   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,