### PR TITLE
Initialize savederrno variable

### DIFF
--- a/libknet/threads_send_recv.c
+++ b/libknet/threads_send_recv.c
@@ -472,7 +472,7 @@ static void _handle_send_to_links(knet_handle_t knet_h, int sockfd, int8_t chann
 	ssize_t inlen = 0;
 	struct iovec iov_in;
 	int msg_recv, i;
-	int savederrno, docallback = 0;
+	int savederrno = 0, docallback = 0;
 
 	if (pthread_rwlock_rdlock(&knet_h->global_rwlock) != 0) {
 		log_debug(knet_h, KNET_SUB_SEND_T, "Unable to get read lock");


### PR DESCRIPTION
This fixes an error seen on F23 arm/gcc:
In file included from threads_send_recv.c:26:0:
threads_send_recv.c: In function '_handle_send_to_links_thread':
logging.h:19:2: error: 'savederrno' may be used uninitialized in this
function [-Werror=maybe-uninitialized]
  log_msg(knet_h, subsys, KNET_LOG_ERR, fmt, ##args)
  ^
threads_send_recv.c:475:6: note: 'savederrno' was declared here
  int savederrno, docallback = 0;
      ^
cc1: all warnings being treated as errors
Makefile:843: recipe for target 'libknet_la-threads_send_recv.lo' failed
make[2]: *** [libknet_la-threads_send_recv.lo] Error 1
make[2]: Leaving directory
'/home/jenkins/workspace/kronosnet/arm-fedora-23-gcc/libknet'
Makefile:506: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory
'/home/jenkins/workspace/kronosnet/arm-fedora-23-gcc'
Makefile:417: recipe for target 'all' failed
make: *** [all] Error 2