### PR TITLE
Move compiler checks to a macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,8 @@ depcomp
 install-sh
 libtoolize
 ltmain.sh
-m4
+m4/lt*
+m4/libtool.m4
 missing
 libtool
 autoscan.log

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 # Run this to generate all the initial makefiles, etc.
-mkdir -p m4
 autoreconf -i -v && echo Now run ./configure and make

--- a/configure.ac
+++ b/configure.ac
@@ -56,20 +56,6 @@ AC_PROG_RANLIB
 AC_CHECK_PROGS([PUBLICAN], [publican], [:])
 AC_CHECK_PROGS([PKGCONFIG], [pkg-config])
 
-## local helper functions
-# this function checks if CC support options passed as
-# args. Global CFLAGS are ignored during this test.
-cc_supports_flag() {
-	saveCPPFLAGS="$CPPFLAGS"
-	CPPFLAGS="$@"
-	AC_MSG_CHECKING([whether $CC supports "$@"])
-	AC_PREPROC_IFELSE([AC_LANG_PROGRAM([])],
-			  [RC=0; AC_MSG_RESULT([yes])],
-			  [RC=1; AC_MSG_RESULT([no])])
-	CPPFLAGS="$saveCPPFLAGS"
-	return $RC
-}
-
 # helper macro to check libs without adding them to LIBS
 check_lib_no_libs() {
 	lib_no_libs_arg1=$1
@@ -287,9 +273,6 @@ WARNLIST="
 	cast-align
 	bad-function-cast
 	missing-format-attribute
-	format=2
-	format-security
-	format-nonliteral
 	no-long-long
 	unsigned-char
 	gnu89-inline
@@ -309,10 +292,24 @@ WARNLIST="
 	unused-variable
 	"
 
+# These need a -Wformat=2 prepended or the check will fail with gcc
+FORMAT_WARNLIST="
+        format-security
+        format-nonliteral
+	"
+
 for j in $WARNLIST; do
-	if cc_supports_flag -W$j; then
-		EXTRA_WARNINGS="$EXTRA_WARNINGS -W$j";
-	fi
+	AX_CHECK_COMPILE_FLAG("-W$j",
+			      [RC=0; EXTRA_WARNINGS="$EXTRA_WARNINGS -W$j"],
+			      [RC=1],
+			      [-Werror])
+done
+
+for j in $FORMAT_WARNLIST; do
+	AX_CHECK_COMPILE_FLAG(-W$j,
+			      [RC=0; EXTRA_WARNINGS="$EXTRA_WARNINGS -Wformat=2 -W$j"],
+			      [RC=1],
+			      [-Wformat=2 -Werror])
 done
 
 CFLAGS="$ENV_CFLAGS $lt_prog_compiler_pic $OPT_CFLAGS $GDB_FLAGS \

--- a/m4/ax_check_compile_flag.m4
+++ b/m4/ax_check_compile_flag.m4
@@ -1,0 +1,74 @@
+# ===========================================================================
+#   http://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_COMPILE_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the current language's compiler
+#   or gives an error.  (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the current language's default
+#   flags (e.g. CFLAGS) when the check is done.  The check is thus made with
+#   the flags: "CFLAGS EXTRA-FLAGS FLAG".  This can for example be used to
+#   force the compiler to issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_COMPILE_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,LINK}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 4
+
+AC_DEFUN([AX_CHECK_COMPILE_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
+AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
+  ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
+  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
+  AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_COMPILE_FLAGS


### PR DESCRIPTION
Currently we test the validity of compiler macros using CPP.
This breaks clang:
error: unknown warning option '-Wunsigned-char' [-Werror,-Wunknown-warning-option]
error: unknown warning option '-Wgnu89-inline' [-Werror,-Wunknown-warning-option]
error: unknown warning option '-Wcpp' [-Werror,-Wunknown-warning-option]
error: unknown warning option '-Wunused-but-set-variable'; did you mean '-Wunused-const-variable'? [-Werror,-Wunknown-warning-option]

Move to an external macro to test the flags and actually use CC
to test them. Also special care needs to be taken with
format-security and format-nonliteral as they both require
-Wformat to be set for gcc to accept them.

Tested on the following combinations:
- F24 x86_64 - gcc 6.1.1
- F24 x86_64 - clang 3.8.0

Signed-off-by: Michele Baldessari <michele@acksyn.org>