### PR TITLE
build: fix wireshark build to use correct libqb headers

### DIFF
--- a/libknet/wireshark/Makefile.am
+++ b/libknet/wireshark/Makefile.am
@@ -28,6 +28,6 @@ kronosnet_la_SOURCES		= \
 				  ../common.c \
 				  ../logging.c \
 				  ../threads_common.c
-kronosnet_la_CFLAGS		= $(wireshark_CFLAGS) -DPLUGINPATH="\"$(pkglibdir)\"" -DWIRESHARK_BUILD=1
+kronosnet_la_CFLAGS		= $(libqb_CFLAGS) $(wireshark_CFLAGS) -DPLUGINPATH="\"$(pkglibdir)\"" -DWIRESHARK_BUILD=1
 kronosnet_la_LDFLAGS		= -module -avoid-version -export-dynamic
 kronosnet_la_LIBADD		= $(wireshark_LIBS)


### PR DESCRIPTION
Fix wireshark plugin build to use correct libqb headers.